### PR TITLE
Add interactive ChatGPT zsh plugin with session management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+sessions/*.json
+!sessions/default.json
+config/api_key
+*.log

--- a/README.md
+++ b/README.md
@@ -1,15 +1,90 @@
-## zsh-chatgpt
+# zsh-chatgpt
 
-Terminal ChatGPT interface with memory, streaming, and shell context injection.
+Terminal ChatGPT interface with session memory, streaming output and shell context injection.
 
-### ✅ Features:
-- Uses official OpenAI API (`gpt-4`, `gpt-3.5`)
-- Streaming output with typing effect
-- Full session memory using JSON
-- Optional context injection (e.g. shell history)
+## Features
 
-### 🚀 Install:
-```bash
+- Uses the official OpenAI API with streaming responses
+- Multiple models (`-m gpt-4o`, `-m o3`, ...)
+- Session management: `--session`, `--new-session`, `--list`, `--clear`
+- Automatically injects recent shell history into each prompt
+- Optional TUI helpers via `fzf` and `gum`
+- Markdown rendering through `glow` or `bat`
+- `--markdown` flag renders responses via `glow` or `bat`
+- Image generation with `--image`
+- Logs every conversation to `~/.chatgpt_logs/`
+- API key stored securely in `~/.config/zsh-chatgpt/api_key`
+- Config overrides via `~/.config/zsh-chatgpt/config.zsh`
+- Retries transient network errors by default
+
+## Installation
+
+```zsh
+# with git
 git clone https://github.com/youruser/zsh-chatgpt ~/.zsh-chatgpt
 echo "source ~/.zsh-chatgpt/chatgpt.plugin.zsh" >> ~/.zshrc
-source ~/.zshrc
+
+# or using zinit
+zinit light youruser/zsh-chatgpt
+```
+
+On first run the plugin prompts for your OpenAI API key and stores it with `chmod 600`.
+
+## Usage
+
+Start an interactive session:
+
+```bash
+chatgpt
+```
+
+Ask a single question:
+
+```bash
+chatgpt "Write a haiku about shells"
+```
+
+Switch or create sessions:
+
+```bash
+chatgpt --session work
+chatgpt --new-session demo
+```
+
+Generate an image:
+
+```bash
+chatgpt --image "A cat hacking on a laptop"
+```
+
+List or clear sessions:
+
+```bash
+chatgpt --list
+chatgpt --clear
+```
+
+Additional context flags:
+
+- `--file path/to/file` – include file contents
+- `--cmd "ls -al"` – include command output
+- `--pipe` – read extra context from STDIN
+- `--markdown` – render final response with glow or bat
+
+Logs are written to `~/.chatgpt_logs/SESSION_YYYYMMDD.md`.
+
+Optional settings can be placed in `~/.config/zsh-chatgpt/config.zsh`, e.g.:
+
+```zsh
+OPENAI_MODEL=o3
+CHAT_SHELL_HISTORY_LINES=50
+```
+
+## Dependencies
+
+`curl`, `jq` and optionally `fzf`, `gum`, `glow` or `bat` for enhanced UI. Missing optional tools are warned at runtime.
+
+## License
+
+MIT
+

--- a/bin/chatgpt
+++ b/bin/chatgpt
@@ -1,56 +1,247 @@
 #!/usr/bin/env zsh
 
-chatgpt() {
-  emulate -L zsh
-  setopt extended_glob
-  local user_input session_file tmpfile shell_context
-  session_file="${CHAT_SESSION_FILE:-$HOME/.chatgpt_session.json}"
-  tmpfile="$(mktemp)"
+# Main CLI for zsh-chatgpt
 
-  # Ensure session file exists
-  [[ ! -f "$session_file" ]] && echo '[]' > "$session_file"
+set -euo pipefail
 
-  # Function to get shell context
-  get_shell_context() {
-    history | tail -n ${CHAT_SHELL_HISTORY_LINES:-5} | sed 's/^/ - /'
-  }
+script_dir=${0:A:h}
+source "$script_dir/../config/config.zsh"
+source "$script_dir/../utils/ui.zsh"
+require_cmd curl jq || exit 1
+warn_optional_cmds
 
-  while true; do
-    print -n "%F{cyan}You:%f "
-    read -r user_input
-    [[ "$user_input" == "exit" || "$user_input" == "quit" ]] && break
+usage() {
+  cat <<'EOF'
+Usage: chatgpt [options] [prompt]
 
-    shell_context=$(get_shell_context)
+Options:
+  -m, --model <name>      Select model (default: $OPENAI_MODEL)
+  --session <name>        Use existing session
+  --new-session <name>    Create and switch to a new session
+  --list                  List available sessions
+  --clear                 Clear current session conversation
+  --image                 Generate image instead of chat completion
+  --file <path>           Include file contents as context
+  --cmd <command>         Include command output as context
+  --pipe                  Read additional context from STDIN
+  --markdown              Render final response with glow or bat
+  -h, --help              Show this help
 
-    # Inject context into user input
-    full_prompt="Context:\n$shell_context\n\nMessage:\n$user_input"
+Run without a prompt to enter interactive chat mode.
+EOF
+}
 
-    # Append user prompt
-    jq --arg content "$full_prompt" \
-       '. += [{"role":"user","content":$content}]' \
-       "$session_file" > "$tmpfile" && mv "$tmpfile" "$session_file"
+# -------------------------------------------------------------
 
-    print -n "%F{green}ChatGPT:%f "
-    curl -sS -N \
-      -H "Authorization: Bearer $OPENAI_API_KEY" \
-      -H "Content-Type: application/json" \
-      -d @- "$OPENAI_API_URL" <<EOF | while read -r line; do
+model=$OPENAI_MODEL
+session=$CHATGPT_DEFAULT_SESSION
+new_session=
+clear=false
+list=false
+image=false
+markdown=false
+file=""
+cmd=""
+from_pipe=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -m|--model) model="$2"; shift;;
+    --session) session="$2"; shift;;
+    --new-session) new_session="$2"; shift;;
+    --clear) clear=true;;
+    --list) list=true;;
+    --image) image=true;;
+    --file) file="$2"; shift;;
+    --cmd) cmd="$2"; shift;;
+    --pipe) from_pipe=true;;
+    --markdown) markdown=true;;
+    -h|--help) usage; exit 0;;
+    --) shift; break;;
+    *) break;;
+  esac
+  shift
+done
+
+prompt="$*"
+
+ensure_dirs
+
+# Manage sessions ------------------------------------------------
+
+session_file="$CHATGPT_SESSION_DIR/${session}.json"
+
+if [[ -n $new_session ]]; then
+  session="$new_session"
+  session_file="$CHATGPT_SESSION_DIR/${session}.json"
+  print '[]' > "$session_file"
+fi
+
+if $list; then
+  for f in "$CHATGPT_SESSION_DIR"/*.json(N); do
+    print ${f:t:r}
+  done
+  exit 0
+fi
+
+if $clear; then
+  : > "$session_file"
+  print "Session '$session' cleared."
+  exit 0
+fi
+
+[[ -f "$session_file" ]] || print '[]' > "$session_file"
+
+# Helper to build context ---------------------------------------
+
+build_prompt() {
+  local msg="$1" extra=""
+  extra+=$'## Shell\n'"$(get_shell_context)"$'\n\n'
+  if [[ -n $file ]]; then
+    if [[ -f $file ]]; then
+      extra+=$"## File: $file\n$(<"$file")\n\n"
+    else
+      printf 'File not found: %s\n' "$file" >&2
+    fi
+  fi
+  if [[ -n $cmd ]]; then
+    local cmd_out
+    cmd_out=$(eval "$cmd" 2>&1) || printf 'Command failed: %s\n' "$cmd" >&2
+    extra+=$"## Command: $cmd\n$cmd_out\n\n"
+  fi
+  if $from_pipe; then
+    local piped
+    piped=$(cat)
+    extra+=$"## STDIN\n$piped\n\n"
+  fi
+  printf '%s\n%s' "$extra" "$msg"
+}
+
+# Chat completion ------------------------------------------------
+
+chat_request() {
+  local user_msg="$1" buffer="" line content attempt=1 success=0 tmp_backup
+  tmp_backup=$(mktemp)
+  cp "$session_file" "$tmp_backup"
+  append_message "user" "$user_msg" "$session_file"
+
+  while (( attempt <= CHATGPT_RETRY_MAX )); do
+    if $markdown; then
+      buffer=$(curl -sS --fail \
+        -H "Authorization: Bearer $OPENAI_API_KEY" \
+        -H "Content-Type: application/json" \
+        -d @- "$OPENAI_API_URL" <<EOF | jq -r '.choices[0].message.content'
 {
-  "model": "$OPENAI_MODEL",
+  "model": "$model",
+  "messages": $(cat "$session_file")
+}
+EOF
+      )
+      if (( $? == 0 )); then
+        render_markdown "$buffer"
+        success=1
+      else
+        success=0
+      fi
+    else
+      buffer=""
+      curl -sS --fail -N \
+        -H "Authorization: Bearer $OPENAI_API_KEY" \
+        -H "Content-Type: application/json" \
+        -d @- "$OPENAI_API_URL" <<EOF | while IFS= read -r line; do
+{
+  "model": "$model",
   "stream": true,
   "messages": $(cat "$session_file")
 }
 EOF
-      [[ "$line" == "data: [DONE]" ]] && break
-      local content=$(echo "$line" | sed 's/^data: //' | jq -r '.choices[0].delta.content // empty')
-      print -n -- "$content"
-    done
-    echo
+        [[ "$line" == "data: [DONE]" ]] && break
+        content=$(echo "$line" | sed 's/^data: //' | jq -r '.choices[0].delta.content // empty')
+        [[ -n $content ]] || continue
+        print -n -- "$content"
+        buffer+="$content"
+      done
+      (( ${pipestatus[1]} == 0 )) && success=1 || success=0
+      [[ $success -eq 1 ]] && echo
+    fi
+    [[ $success -eq 1 ]] && break
+    echo "Retrying... ($attempt/$CHATGPT_RETRY_MAX)" >&2
+    (( attempt++ ))
+    sleep $CHATGPT_RETRY_SLEEP
+  done
 
-    # Extract last assistant message from session and persist
-    last_reply=$(jq -r '.[-1].content' "$session_file")
-    [[ -n "$last_reply" ]] && jq --arg content "$last_reply" \
-      '. += [{"role":"assistant","content":$content}]' \
-      "$session_file" > "$tmpfile" && mv "$tmpfile" "$session_file"
+  if (( success == 0 )); then
+    mv "$tmp_backup" "$session_file"
+    rm -f "$tmp_backup"
+    echo 'Error contacting OpenAI API' >&2
+    return 1
+  fi
+  rm -f "$tmp_backup"
+
+  append_message "assistant" "$buffer" "$session_file"
+  log_turn "$session" "$user_msg" "$buffer"
+}
+
+# Image generation -----------------------------------------------
+
+image_request() {
+  local prompt="$1" resp attempt=1
+  while (( attempt <= CHATGPT_RETRY_MAX )); do
+    resp=$(curl -sS --fail \
+      -H "Authorization: Bearer $OPENAI_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d @- "$OPENAI_IMAGE_URL" <<EOF
+{
+  "model": "$OPENAI_IMAGE_MODEL",
+  "prompt": "$prompt"
+}
+EOF
+    ) && break
+    echo "Retrying... ($attempt/$CHATGPT_RETRY_MAX)" >&2
+    (( attempt++ ))
+    sleep $CHATGPT_RETRY_SLEEP
+  done
+  [[ -n $resp ]] || { echo 'Error contacting OpenAI API' >&2; return 1; }
+  echo "$resp" | jq -r '.data[0].url'
+}
+
+# Handle single message ------------------------------------------
+
+handle_message() {
+  local input="$1"
+  local built
+  built=$(build_prompt "$input")
+  if $image; then
+    local url
+    url=$(image_request "$built") || return 1
+    print -- "$url"
+  else
+    chat_request "$built" || return 1
+  fi
+}
+
+# Interactive loop ------------------------------------------------
+
+interactive_loop() {
+  local msg
+  while true; do
+    if command -v gum >/dev/null; then
+      msg=$(gum input --prompt="You: ")
+    else
+      printf "%F{cyan}You:%f "
+      read -r msg
+    fi
+    [[ -z $msg ]] && continue
+    [[ $msg == exit || $msg == quit ]] && break
+    handle_message "$msg"
   done
 }
+
+# Entry -----------------------------------------------------------
+
+if [[ -n $prompt || $from_pipe || -n $file || -n $cmd ]]; then
+  handle_message "$prompt"
+else
+  interactive_loop
+fi
+

--- a/chatgpt.plugin.zsh
+++ b/chatgpt.plugin.zsh
@@ -1,4 +1,12 @@
-# Load configuration and path setup
+# Entry point for zsh-chatgpt plugin
+
 source "${0:A:h}/config/config.zsh"
-fpath=(${0:A:h}/bin $fpath)
-autoload -Uz chatgpt
+
+# Add bundled scripts to PATH
+path=(${0:A:h}/bin $path)
+
+# Enable completion
+fpath=(${0:A:h}/completions $fpath)
+autoload -Uz _chatgpt
+compdef _chatgpt chatgpt
+

--- a/completions/_chatgpt
+++ b/completions/_chatgpt
@@ -1,3 +1,26 @@
 #compdef chatgpt
 
-_arguments '1:command:(new switch list clear exit --image --file --cmd --pipe)'
+# Zsh completion for chatgpt CLI
+
+local -a models
+models=(gpt-4o gpt-4.1 o3 o3-mini gpt-5)
+
+_chatgpt_sessions() {
+  local dir=${CHATGPT_SESSION_DIR:-$HOME/.chatgpt_sessions}
+  _files -W "$dir" -g '*.json'
+}
+
+_arguments -C \
+  '(-h --help)'{-h,--help}'[show help]' \
+  '(-m --model)'{-m,--model}'[model]:model:((gpt-4o gpt-4.1 o3 o3-mini gpt-5))' \
+  '--session[use session]:session name:_chatgpt_sessions' \
+  '--new-session[new session]:session name:' \
+  '--list[list sessions]' \
+  '--clear[clear session]' \
+  '--image[generate image]' \
+  '--file[include file]:file:_files' \
+  '--cmd[include command]:command:_command_names' \
+  '--pipe[read from stdin]' \
+  '--markdown[render output via glow or bat]' \
+  '*:prompt:'
+

--- a/config/config.zsh
+++ b/config/config.zsh
@@ -1,7 +1,43 @@
-# Securely store your API key
-export OPENAI_API_KEY="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"
+# Configuration for zsh-chatgpt
 
-export OPENAI_MODEL="gpt-4"
-export OPENAI_API_URL="https://api.openai.com/v1/chat/completions"
-export CHAT_SESSION_FILE="${HOME}/.chatgpt_session.json"
-export CHAT_SHELL_HISTORY_LINES=5
+# Load API key securely. The key is stored in
+#   ~/.config/zsh-chatgpt/api_key
+# and retrieved via utils/key.zsh. This file must exist
+# with permissions 600. Users will be prompted for the key
+# the first time the plugin runs.
+
+source "${0:a:h}/../utils/key.zsh"
+get_api_key
+
+# ----- Default configuration -----
+
+# Default chat model. Can be overridden via the -m/--model flag.
+: ${OPENAI_MODEL:=gpt-4o}
+
+# Default image model used by --image flag.
+: ${OPENAI_IMAGE_MODEL:=gpt-image-1}
+
+# API endpoints
+: ${OPENAI_API_URL:=https://api.openai.com/v1/chat/completions}
+: ${OPENAI_IMAGE_URL:=https://api.openai.com/v1/images/generations}
+
+# Where session JSON files and logs are stored
+: ${CHATGPT_SESSION_DIR:="$HOME/.chatgpt_sessions"}
+: ${CHATGPT_LOG_DIR:="$HOME/.chatgpt_logs"}
+
+# Name of the default session when none is specified
+: ${CHATGPT_DEFAULT_SESSION:=default}
+
+# Number of previous shell commands to include as context
+: ${CHAT_SHELL_HISTORY_LINES:=20}
+
+# Retry behaviour for API requests
+: ${CHATGPT_RETRY_MAX:=3}
+: ${CHATGPT_RETRY_SLEEP:=2}
+
+# Allow user overrides via ~/.config/zsh-chatgpt/config.zsh
+user_cfg="$HOME/.config/zsh-chatgpt/config.zsh"
+if [[ -f $user_cfg ]]; then
+  source "$user_cfg"
+fi
+

--- a/tests/session_management.bats
+++ b/tests/session_management.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+  export CHATGPT_SESSION_DIR="$BATS_TEST_TMPDIR/sessions"
+  export CHATGPT_LOG_DIR="$BATS_TEST_TMPDIR/logs"
+  mkdir -p "$CHATGPT_SESSION_DIR" "$CHATGPT_LOG_DIR"
+  export OPENAI_API_KEY=test
+  export CHATGPT_SUPPRESS_WARN=1
+}
+
+@test "creates new session" {
+  run ./bin/chatgpt --new-session foo --list
+  [ "$status" -eq 0 ]
+  [ -f "$CHATGPT_SESSION_DIR/foo.json" ]
+}
+
+@test "lists sessions" {
+  touch "$CHATGPT_SESSION_DIR/bar.json"
+  run ./bin/chatgpt --list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bar"* ]]
+}
+
+@test "clears session" {
+  echo '[{"role":"user","content":"hi"}]' > "$CHATGPT_SESSION_DIR/clear.json"
+  run ./bin/chatgpt --session clear --clear
+  [ "$status" -eq 0 ]
+  [ ! -s "$CHATGPT_SESSION_DIR/clear.json" ]
+}
+

--- a/utils/key.zsh
+++ b/utils/key.zsh
@@ -1,9 +1,21 @@
 get_api_key() {
   local key_file="$HOME/.config/zsh-chatgpt/api_key"
+
+  # Allow overriding via existing environment variable
+  if [[ -n ${OPENAI_API_KEY:-} ]]; then
+    return
+  fi
+
   if [[ ! -f "$key_file" ]]; then
-    mkdir -p "$(dirname "$key_file")"
-    local newkey=$(gum input --password --prompt="Enter your OpenAI API Key: ")
-    echo "$newkey" > "$key_file"
+    mkdir -p "${key_file:h}"
+    local newkey
+    if command -v gum >/dev/null; then
+      newkey=$(gum input --password --prompt="Enter your OpenAI API key: ")
+    else
+      printf "Enter your OpenAI API key: "
+      read -r newkey
+    fi
+    print -- "$newkey" > "$key_file"
     chmod 600 "$key_file"
   fi
   export OPENAI_API_KEY=$(<"$key_file")

--- a/utils/ui.zsh
+++ b/utils/ui.zsh
@@ -1,38 +1,84 @@
 # Utility functions for zsh-chatgpt
 
-ensure_session_dir() {
-  # Ensure the directory for the session file exists
-  local dir
-  dir=$(dirname "$CHAT_SESSION_FILE")
-  mkdir -p "$dir"
+# Ensure necessary directories exist
+ensure_dirs() {
+  mkdir -p "$CHATGPT_SESSION_DIR" "$CHATGPT_LOG_DIR"
 }
 
+# Check that required commands exist
+require_cmd() {
+  for cmd in "$@"; do
+    if ! command -v "$cmd" >/dev/null; then
+      printf 'Required command not found: %s\n' "$cmd" >&2
+      return 1
+    fi
+  done
+}
+
+# Warn about missing optional utilities that enhance UX
+warn_optional_cmds() {
+  [[ -n ${CHATGPT_SUPPRESS_WARN:-} ]] && return
+  command -v gum >/dev/null || printf 'Optional command not found: gum (for nicer prompts)\n' >&2
+  command -v fzf >/dev/null || printf 'Optional command not found: fzf (for session selection)\n' >&2
+  if ! command -v glow >/dev/null && ! command -v bat >/dev/null; then
+    printf 'Optional command not found: glow or bat (for markdown rendering)\n' >&2
+  fi
+}
+
+# Fetch the last few commands from shell history and format them
 get_shell_context() {
-  # Get the last few shell history lines and format as bullet points
-  local lines=${CHAT_SHELL_HISTORY_LINES:-5}
-  history | tail -n "$lines" | sed 's/^/ - /'
+  local lines=${CHAT_SHELL_HISTORY_LINES:-20}
+  fc -ln -$lines 2>/dev/null | sed 's/^/ - /'
 }
 
+# Allow the user to pick an existing session using fzf
 select_session() {
-  # Present available session files and let user pick one via fzf
-  local dir
-  dir=$(dirname "$CHAT_SESSION_FILE")
-  local files
-  files=("$dir"/*.json(N))
-  [[ ${#files[@]} -eq 0 ]] && echo "$CHAT_SESSION_FILE" && return
-  local selected
-  selected=$(printf "%s\n" "${files[@]##*/}" | fzf --prompt="Select session: ")
-  echo "$dir/$selected"
+  ensure_dirs
+  local files=("$CHATGPT_SESSION_DIR"/*.json(N))
+  if (( ${#files[@]} == 0 )); then
+    echo "$CHATGPT_SESSION_DIR/$CHATGPT_DEFAULT_SESSION.json"
+    return
+  fi
+  if command -v fzf >/dev/null; then
+    local selected
+    selected=$(printf "%s\n" "${files[@]##*/}" | fzf --prompt="Session> ")
+    [[ -n $selected ]] && echo "$CHATGPT_SESSION_DIR/$selected" || echo "$CHATGPT_SESSION_DIR/$CHATGPT_DEFAULT_SESSION.json"
+  else
+    printf "%s\n" "${files[@]}"
+  fi
 }
 
-append_to_session() {
-  # Append assistant message to the current session JSON file
-  local content="$1"
-  local file="${CHAT_SESSION_FILE}"
+# Render markdown using glow or bat if available
+render_markdown() {
+  local text="$1"
+  if command -v glow >/dev/null; then
+    printf "%s" "$text" | glow -
+  elif command -v bat >/dev/null; then
+    printf "%s" "$text" | bat -l markdown
+  else
+    printf "%s\n" "$text"
+  fi
+}
+
+# Append a message to the session JSON file
+append_message() {
+  local role="$1" content="$2" file="$3"
   local tmpfile
   tmpfile=$(mktemp)
-  if [[ ! -f "$file" ]]; then
-    echo '[]' > "$file"
-  fi
-  jq --arg content "$content" '. + [{"role":"assistant","content":$content}]' "$file" > "$tmpfile" && mv "$tmpfile" "$file"
+  [[ ! -f "$file" ]] && print '[]' > "$file"
+  jq --arg role "$role" --arg content "$content" \
+     '. + [{"role":$role,"content":$content}]' "$file" > "$tmpfile" \
+     && mv "$tmpfile" "$file"
 }
+
+# Log a conversation turn to the log directory
+log_turn() {
+  local session="$1" user="$2" assistant="$3"
+  local logfile="$CHATGPT_LOG_DIR/${session}_$(date +%Y%m%d).md"
+  {
+    printf "### %s\n\n" "$(date '+%Y-%m-%d %H:%M:%S')"
+    printf "**You:** %s\n\n" "$user"
+    printf "**ChatGPT:** %s\n\n" "$assistant"
+  } >> "$logfile"
+}
+


### PR DESCRIPTION
## Summary
- warn when optional helpers like gum, fzf, glow or bat are missing
- add retry logic and stronger error handling for API requests
- cover session management features with bats tests
- restore default session stub and adjust gitignore to keep session directory

## Testing
- `zsh -n bin/chatgpt`
- `zsh -n chatgpt.plugin.zsh`
- `bats tests/session_management.bats`


------
https://chatgpt.com/codex/tasks/task_e_68961596c2bc8324b088fde9402eb687